### PR TITLE
Gob encoding

### DIFF
--- a/tsz.go
+++ b/tsz.go
@@ -53,7 +53,7 @@ type seriesOnDisk struct {
 
 // Implimentation GobEncoder interface
 // https://golang.org/pkg/encoding/gob/#GobEncoder
-func (s Series) GobEncode() ([]byte, error) {
+func (s *Series) GobEncode() ([]byte, error) {
 	s.Lock()
 	defer s.Unlock()
 	pendingBits, pendingCount := s.bw.Pending()

--- a/tsz.go
+++ b/tsz.go
@@ -9,12 +9,16 @@ package tsz
 import (
 	"bytes"
 	"math"
+	"sync"
 
 	"github.com/dgryski/go-bits"
 	"github.com/dgryski/go-bitstream"
 )
 
+// Series is the basic series primitive
+// you can concurrently put values, finish the stream, and create iterators
 type Series struct {
+	sync.Mutex
 
 	// TODO(dgryski): timestamps in the paper are uint64
 
@@ -48,6 +52,8 @@ func New(t0 uint32) *Series {
 }
 
 func (s *Series) Bytes() []byte {
+	s.Lock()
+	defer s.Unlock()
 	return s.buf.Bytes()
 }
 
@@ -60,14 +66,17 @@ func finish(w *bitstream.BitWriter) {
 }
 
 func (s *Series) Finish() {
-
+	s.Lock()
 	if !s.finished {
 		finish(s.bw)
 		s.finished = true
 	}
+	s.Unlock()
 }
 
 func (s *Series) Push(t uint32, v float64) {
+	s.Lock()
+	defer s.Unlock()
 
 	if s.t == 0 {
 		// first point
@@ -132,18 +141,21 @@ func (s *Series) Push(t uint32, v float64) {
 }
 
 func (s *Series) Iter() *Iter {
+	s.Lock()
 	data := s.buf.Bytes()
 	newData := make([]byte, len(data), len(data)+1)
 	copy(newData, data)
+	byt, count := s.bw.Pending()
+	s.Unlock()
 	buf := bytes.NewBuffer(newData)
 	w := bitstream.NewWriter(buf)
-	byt, count := s.bw.Pending()
 	w.Resume(byt, count)
 	finish(w)
 	iter, _ := NewIterator(buf.Bytes())
 	return iter
 }
 
+// Iter lets you iterate over a series.  It is not concurrency-safe.
 type Iter struct {
 	t0 uint32
 

--- a/tsz_test.go
+++ b/tsz_test.go
@@ -1,6 +1,8 @@
 package tsz
 
 import (
+	"io"
+	"sync"
 	"testing"
 	"time"
 )
@@ -136,6 +138,105 @@ func TestRoundtrip(t *testing.T) {
 	if err := it.Err(); err != nil {
 		t.Errorf("it.Err()=%v, want nil", err)
 	}
+}
+
+func writer(s *Series, done chan struct{}, sleep time.Duration) {
+	for _, p := range TwoHoursData {
+		s.Push(p.t, p.v)
+		time.Sleep(sleep)
+	}
+	close(done)
+}
+
+func reader(s *Series, done chan struct{}, errors chan string, wg *sync.WaitGroup, t *testing.T) {
+	// continuously create iterators to verify the data
+	// * when we know the writer is done, we make sure
+	// we do 1 last pass verifying all data
+	// * until then, we only require data to be correct up until
+	// there's no more data returned,and don't require all data to be returned
+	lastPass := false
+	for {
+		select {
+		case <-done:
+			lastPass = true
+		default:
+		}
+		it := s.Iter()
+		iters := 0
+		for _, w := range TwoHoursData {
+			iters += 1
+			if it.Next() {
+				tt, vv := it.Values()
+				if w.t != tt || w.v != vv {
+					errors <- fmt.Sprintf("Values()=(%v,%v), want (%v,%v)\n", tt, vv, w.t, w.v)
+				}
+			} else {
+				if lastPass {
+					errors <- fmt.Sprintf("Next()=false, want true")
+				}
+				// if we're not the last pass, it's ok to not have all data yet, stop looking
+				break
+			}
+		}
+
+		// if not in last pass, Next() may suddenly have a new value now, or not..
+		if lastPass && it.Next() {
+			errors <- fmt.Sprintf("Next()=true, want false")
+		}
+
+		// if not a single value was written yet, we expect an EOF error
+		if iters == 0 {
+			if err := it.Err(); err != io.EOF {
+				errors <- fmt.Sprintf("it.Err()=%v, want EOF", err)
+			}
+			// but if one or more values exist, we should have a clean end of record
+		} else {
+			if err := it.Err(); err != nil {
+				errors <- fmt.Sprintf("it.Err()=%v, want nil. after %d iters", err, iters)
+			}
+		}
+		if lastPass {
+			break
+		}
+	}
+	wg.Done()
+}
+
+func TestConcurrentRoundtripImmediateWrites(t *testing.T) {
+	testConcurrentRoundtrip(t, time.Duration(0))
+}
+func TestConcurrentRoundtrip1MsBetweenWrites(t *testing.T) {
+	testConcurrentRoundtrip(t, time.Millisecond)
+}
+func TestConcurrentRoundtrip10MsBetweenWrites(t *testing.T) {
+	testConcurrentRoundtrip(t, 10*time.Millisecond)
+}
+
+// poorly synchronized. we want to test reading while writing, after finishing writing
+// we could introduce explicit synchronization but i don't see a simple way to do so
+// in a way that doesn't reduce the possible timing overlaps.
+func testConcurrentRoundtrip(t *testing.T, sleep time.Duration) {
+
+	s := New(TwoHoursData[0].t)
+	done := make(chan struct{})
+	errors := make(chan string)
+
+	wg := &sync.WaitGroup{}
+
+	go func() {
+		for err := range errors {
+			t.Error(err)
+		}
+	}()
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go reader(s, done, errors, wg, t)
+	}
+
+	go writer(s, done, sleep)
+
+	wg.Wait()
 }
 
 func BenchmarkEncode(b *testing.B) {


### PR DESCRIPTION
This allows Series to be serialized to a byte array for writing to disk or sending over the network.  The byte array can then be read and the Series re-constructed with the original data and state.

This was built out of a need to be able restart an application using go-tsz without losing data.