### PR TITLE
More evaluation cases

### DIFF
--- a/eval/helper.go
+++ b/eval/helper.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"math"
+)
+
+func Round(f float64) float64 {
+	if f < 0 {
+		return math.Ceil(f - 0.5)
+	}
+	return math.Floor(f + .5)
+}
+
+func RoundNum(f float64, places int) float64 {
+	shift := math.Pow(10, float64(places))
+	return Round(f*shift) / shift
+}

--- a/eval/main.go
+++ b/eval/main.go
@@ -29,8 +29,25 @@ var SmallRangePosf = make([]tsz.Point, 60*24)
 var LargeRangePosf = make([]tsz.Point, 60*24)
 var SmallRangePos0f = make([]tsz.Point, 60*24)
 var LargeRangePos0f = make([]tsz.Point, 60*24)
+
+var RandomTinyPosf = make([]tsz.Point, 60*24)
+var RandomTinyf = make([]tsz.Point, 60*24)
+var RandomTinyPos2f = make([]tsz.Point, 60*24)
+var RandomTiny2f = make([]tsz.Point, 60*24)
+var RandomTinyPos1f = make([]tsz.Point, 60*24)
+var RandomTiny1f = make([]tsz.Point, 60*24)
+var RandomTinyPos0f = make([]tsz.Point, 60*24)
+var RandomTiny0f = make([]tsz.Point, 60*24)
+
 var RandomSmallPosf = make([]tsz.Point, 60*24)
 var RandomSmallf = make([]tsz.Point, 60*24)
+var RandomSmallPos2f = make([]tsz.Point, 60*24)
+var RandomSmall2f = make([]tsz.Point, 60*24)
+var RandomSmallPos1f = make([]tsz.Point, 60*24)
+var RandomSmall1f = make([]tsz.Point, 60*24)
+var RandomSmallPos0f = make([]tsz.Point, 60*24)
+var RandomSmall0f = make([]tsz.Point, 60*24)
+
 var RandomLargePosf = make([]tsz.Point, 60*24)
 var RandomLargef = make([]tsz.Point, 60*24)
 var RandomLargePos0f = make([]tsz.Point, 60*24)
@@ -84,16 +101,34 @@ func main() {
 		ConstantNearMinf[i] = tsz.Point{-math.MaxFloat64 / 100, ts}
 		ConstantNearMax0f[i] = tsz.Point{math.Floor(ConstantNearMaxf[i].V), ts}
 		ConstantNearMin0f[i] = tsz.Point{math.Floor(ConstantNearMinf[i].V), ts}
-		SmallRangePosd[i] = tsz.Point{testdata.TwoHoursData[i%120].V, ts}
-		LargeRangePosd[i] = tsz.Point{testdata.TwoHoursData[i%120].V * 1000000, ts}
-		SmallRangePosf[i] = tsz.Point{float64(testdata.TwoHoursData[i%120].V) * 1.234567, ts}
-		LargeRangePosf[i] = tsz.Point{float64(testdata.TwoHoursData[i%120].V) * 0.00001234567 * math.MaxFloat64, ts}
-		SmallRangePos0f[i] = tsz.Point{math.Floor(SmallRangePosf[i].V), ts}
-		LargeRangePos0f[i] = tsz.Point{math.Floor(LargeRangePosf[i].V), ts}
-		RandomSmallPosf[i] = tsz.Point{rand.ExpFloat64(), ts}
-		RandomSmallf[i] = tsz.Point{rand.NormFloat64(), ts}
-		RandomLargePosf[i] = tsz.Point{rand.ExpFloat64() * 0.0001 * math.MaxFloat64, ts}
-		RandomLargef[i] = tsz.Point{rand.NormFloat64() * 0.0001 * math.MaxFloat64, ts}
+
+		SmallRangePosd[i] = tsz.Point{testdata.TwoHoursData[i%120].V, ts}                                            // THD is 650 - 860, so this is 0-119
+		LargeRangePosd[i] = tsz.Point{testdata.TwoHoursData[i%120].V * 1000000, ts}                                  // 0 to 119M
+		SmallRangePosf[i] = tsz.Point{float64(testdata.TwoHoursData[i%120].V) * 1.234567, ts}                        // 0-150
+		LargeRangePosf[i] = tsz.Point{float64(testdata.TwoHoursData[i%120].V) * 0.00001234567 * math.MaxFloat64, ts} // 0-maxfloat/1000
+		SmallRangePos0f[i] = tsz.Point{math.Floor(SmallRangePosf[i].V), ts}                                          // 0-150
+		LargeRangePos0f[i] = tsz.Point{math.Floor(LargeRangePosf[i].V), ts}                                          // 0-maxfloat/1000
+
+		RandomTinyPosf[i] = tsz.Point{rand.ExpFloat64(), ts} // 0-inf, but most vals are very low, mostly between 0 and 2, rarely goes over 10
+		RandomTinyf[i] = tsz.Point{rand.NormFloat64(), ts}   // -inf to + inf, as many pos as neg, but similar as above, rarely goes under -10 or over +10
+		RandomTinyPos2f[i] = tsz.Point{RoundNum(RandomTinyPosf[i].V, 2), ts}
+		RandomTiny2f[i] = tsz.Point{RoundNum(RandomTinyPosf[i].V, 2), ts}
+		RandomTinyPos1f[i] = tsz.Point{RoundNum(RandomTinyPosf[i].V, 1), ts}
+		RandomTiny1f[i] = tsz.Point{RoundNum(RandomTinyPosf[i].V, 1), ts}
+		RandomTinyPos0f[i] = tsz.Point{math.Floor(RandomTinyPosf[i].V), ts}
+		RandomTiny0f[i] = tsz.Point{math.Floor(RandomTinyPosf[i].V), ts}
+
+		RandomSmallPosf[i] = tsz.Point{RandomTinyPosf[i].V * 100, ts} // 0-inf, but most vals are very low, mostly between 0 and 200, rarely goes over 1000
+		RandomSmallf[i] = tsz.Point{RandomTinyf[i].V * 100, ts}       // -inf to + inf, as many pos as neg, but similar as above, rarely goes under -1000 or over +1000
+		RandomSmallPos2f[i] = tsz.Point{RoundNum(RandomSmallPosf[i].V, 2), ts}
+		RandomSmall2f[i] = tsz.Point{RoundNum(RandomSmallPosf[i].V, 2), ts}
+		RandomSmallPos1f[i] = tsz.Point{RoundNum(RandomSmallPosf[i].V, 1), ts}
+		RandomSmall1f[i] = tsz.Point{RoundNum(RandomSmallPosf[i].V, 1), ts}
+		RandomSmallPos0f[i] = tsz.Point{math.Floor(RandomSmallPosf[i].V), ts}
+		RandomSmall0f[i] = tsz.Point{math.Floor(RandomSmallPosf[i].V), ts}
+
+		RandomLargePosf[i] = tsz.Point{rand.ExpFloat64() * 0.0001 * math.MaxFloat64, ts} // 0-inf, rarely goes over maxfloat/1000
+		RandomLargef[i] = tsz.Point{rand.NormFloat64() * 0.0001 * math.MaxFloat64, ts}   // same buth also negative
 		RandomLargePos0f[i] = tsz.Point{math.Floor(RandomLargePosf[i].V), ts}
 		RandomLarge0f[i] = tsz.Point{math.Floor(RandomLargef[i].V), ts}
 	}
@@ -144,8 +179,25 @@ func main() {
 	fmt.Fprintf(w, "pick-range large pos       f\t"+do(LargeRangePosf)+"\n")
 	fmt.Fprintf(w, "pick-range small pos     .0f\t"+do(SmallRangePos0f)+"\n")
 	fmt.Fprintf(w, "pick-range large pos     .0f\t"+do(LargeRangePos0f)+"\n")
+	fmt.Fprintf(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n")
+	fmt.Fprintf(w, "pick-rand  tiny  pos       f\t"+do(RandomTinyPosf)+"\n")
+	fmt.Fprintf(w, "pick-rand  tiny  pos/neg   f\t"+do(RandomTinyf)+"\n")
+	fmt.Fprintf(w, "pick-rand  tiny  pos     .2f\t"+do(RandomTinyPos2f)+"\n")
+	fmt.Fprintf(w, "pick-rand  tiny  pos/neg .2f\t"+do(RandomTiny2f)+"\n")
+	fmt.Fprintf(w, "pick-rand  tiny  pos     .1f\t"+do(RandomTinyPos1f)+"\n")
+	fmt.Fprintf(w, "pick-rand  tiny  pos/neg .1f\t"+do(RandomTiny1f)+"\n")
+	fmt.Fprintf(w, "pick-rand  tiny  pos     .0f\t"+do(RandomTinyPos0f)+"\n")
+	fmt.Fprintf(w, "pick-rand  tiny  pos/neg .0f\t"+do(RandomTiny0f)+"\n")
+	fmt.Fprintf(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n")
 	fmt.Fprintf(w, "pick-rand  small pos       f\t"+do(RandomSmallPosf)+"\n")
 	fmt.Fprintf(w, "pick-rand  small pos/neg   f\t"+do(RandomSmallf)+"\n")
+	fmt.Fprintf(w, "pick-rand  small pos     .2f\t"+do(RandomSmallPos2f)+"\n")
+	fmt.Fprintf(w, "pick-rand  small pos/neg .2f\t"+do(RandomSmall2f)+"\n")
+	fmt.Fprintf(w, "pick-rand  small pos     .1f\t"+do(RandomSmallPos1f)+"\n")
+	fmt.Fprintf(w, "pick-rand  small pos/neg .1f\t"+do(RandomSmall1f)+"\n")
+	fmt.Fprintf(w, "pick-rand  small pos     .0f\t"+do(RandomSmallPos0f)+"\n")
+	fmt.Fprintf(w, "pick-rand  small pos/neg .0f\t"+do(RandomSmall0f)+"\n")
+	fmt.Fprintf(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n")
 	fmt.Fprintf(w, "pick-rand  large pos       f\t"+do(RandomLargePosf)+"\n")
 	fmt.Fprintf(w, "pick-rand  large pos/neg   f\t"+do(RandomLargef)+"\n")
 	fmt.Fprintf(w, "pick-rand  large pos     .0f\t"+do(RandomLargePos0f)+"\n")

--- a/eval/main.go
+++ b/eval/main.go
@@ -11,42 +11,95 @@ import (
 )
 
 // collection of 24h worth of minutely points, with different characteristics.
-var DataZeroFloats = make([]testdata.Point, 60*24)
-var DataSameFloats = make([]testdata.Point, 60*24)
-var DataSmallRangePosInts = make([]testdata.Point, 60*24)
-var DataSmallRangePosFloats = make([]testdata.Point, 60*24)
-var DataLargeRangePosFloats = make([]testdata.Point, 60*24)
-var DataRandomPosFloats = make([]testdata.Point, 60*24)
-var DataRandomFloats = make([]testdata.Point, 60*24)
+var ConstantZero = make([]tsz.Point, 60*24)
+var ConstantOne = make([]tsz.Point, 60*24)
+var Batch100ZeroOne = make([]tsz.Point, 60*24)
+var FlappingZeroOne = make([]tsz.Point, 60*24)
+var ConstantPos3f = make([]tsz.Point, 60*24)
+var ConstantNeg3f = make([]tsz.Point, 60*24)
+var ConstantPos0f = make([]tsz.Point, 60*24)
+var ConstantNeg0f = make([]tsz.Point, 60*24)
+var ConstantNearMaxf = make([]tsz.Point, 60*24)
+var ConstantNearMinf = make([]tsz.Point, 60*24)
+var ConstantNearMax0f = make([]tsz.Point, 60*24)
+var ConstantNearMin0f = make([]tsz.Point, 60*24)
+var SmallRangePosd = make([]tsz.Point, 60*24)
+var LargeRangePosd = make([]tsz.Point, 60*24)
+var SmallRangePosf = make([]tsz.Point, 60*24)
+var LargeRangePosf = make([]tsz.Point, 60*24)
+var SmallRangePos0f = make([]tsz.Point, 60*24)
+var LargeRangePos0f = make([]tsz.Point, 60*24)
+var RandomSmallPosf = make([]tsz.Point, 60*24)
+var RandomSmallf = make([]tsz.Point, 60*24)
+var RandomLargePosf = make([]tsz.Point, 60*24)
+var RandomLargef = make([]tsz.Point, 60*24)
+var RandomLargePos0f = make([]tsz.Point, 60*24)
+var RandomLarge0f = make([]tsz.Point, 60*24)
 
 func init() {
 	for i := 0; i < len(DataZeroFloats); i++ {
-		DataZeroFloats[i] = testdata.Point{float64(0), uint32(i * 60)}
+		DataZeroFloats[i] = tsz.Point{float64(0), uint32(i * 60)}
 	}
 	for i := 0; i < len(DataSameFloats); i++ {
-		DataSameFloats[i] = testdata.Point{float64(1234.567), uint32(i * 60)}
+		DataSameFloats[i] = tsz.Point{float64(1234.567), uint32(i * 60)}
 	}
 	for i := 0; i < len(DataSmallRangePosInts); i++ {
-		DataSmallRangePosInts[i] = testdata.Point{testdata.TwoHoursData[i%120].V, uint32(i * 60)}
+		DataSmallRangePosInts[i] = tsz.Point{testdata.TwoHoursData[i%120].V, uint32(i * 60)}
 	}
 	for i := 0; i < len(DataSmallRangePosFloats); i++ {
 		v := float64(testdata.TwoHoursData[i%120].V) * 1.2
-		DataSmallRangePosFloats[i] = testdata.Point{v, uint32(i * 60)}
+		DataSmallRangePosFloats[i] = tsz.Point{v, uint32(i * 60)}
 	}
 	for i := 0; i < len(DataLargeRangePosFloats); i++ {
 		v := (float64(testdata.TwoHoursData[i%120].V) / 1000) * math.MaxFloat64
-		DataLargeRangePosFloats[i] = testdata.Point{v, uint32(i * 60)}
+		DataLargeRangePosFloats[i] = tsz.Point{v, uint32(i * 60)}
 	}
 	for i := 0; i < len(DataRandomPosFloats); i++ {
-		DataRandomPosFloats[i] = testdata.Point{rand.ExpFloat64(), uint32(i * 60)}
+		DataRandomPosFloats[i] = tsz.Point{rand.ExpFloat64(), uint32(i * 60)}
 	}
 	for i := 0; i < len(DataRandomFloats); i++ {
-		DataRandomFloats[i] = testdata.Point{rand.NormFloat64(), uint32(i * 60)}
+		DataRandomFloats[i] = tsz.Point{rand.NormFloat64(), uint32(i * 60)}
 	}
 }
 func main() {
+	for i := 0; i < 60*24; i++ {
+		ts := uint32(i * 60)
+		ConstantZero[i] = tsz.Point{float64(0), ts}
+		ConstantOne[i] = tsz.Point{float64(1), ts}
+		if i%200 < 100 {
+			Batch100ZeroOne[i] = tsz.Point{float64(0), ts}
+		} else {
+			Batch100ZeroOne[i] = tsz.Point{float64(1), ts}
+		}
+		if i%2 == 0 {
+			FlappingZeroOne[i] = tsz.Point{float64(0), ts}
+		} else {
+			FlappingZeroOne[i] = tsz.Point{float64(1), ts}
+		}
+		ConstantPos3f[i] = tsz.Point{float64(1234.567), ts}
+		ConstantNeg3f[i] = tsz.Point{float64(-1234.567), ts}
+		ConstantPos0f[i] = tsz.Point{float64(1234), ts}
+		ConstantNeg0f[i] = tsz.Point{float64(-1235), ts}
+		ConstantNearMaxf[i] = tsz.Point{math.MaxFloat64 / 100, ts}
+		ConstantNearMinf[i] = tsz.Point{-math.MaxFloat64 / 100, ts}
+		ConstantNearMax0f[i] = tsz.Point{math.Floor(ConstantNearMaxf[i].V), ts}
+		ConstantNearMin0f[i] = tsz.Point{math.Floor(ConstantNearMinf[i].V), ts}
+		SmallRangePosd[i] = tsz.Point{testdata.TwoHoursData[i%120].V, ts}
+		LargeRangePosd[i] = tsz.Point{testdata.TwoHoursData[i%120].V * 1000000, ts}
+		SmallRangePosf[i] = tsz.Point{float64(testdata.TwoHoursData[i%120].V) * 1.234567, ts}
+		LargeRangePosf[i] = tsz.Point{float64(testdata.TwoHoursData[i%120].V) * 0.00001234567 * math.MaxFloat64, ts}
+		SmallRangePos0f[i] = tsz.Point{math.Floor(SmallRangePosf[i].V), ts}
+		LargeRangePos0f[i] = tsz.Point{math.Floor(LargeRangePosf[i].V), ts}
+		RandomSmallPosf[i] = tsz.Point{rand.ExpFloat64(), ts}
+		RandomSmallf[i] = tsz.Point{rand.NormFloat64(), ts}
+		RandomLargePosf[i] = tsz.Point{rand.ExpFloat64() * 0.0001 * math.MaxFloat64, ts}
+		RandomLargef[i] = tsz.Point{rand.NormFloat64() * 0.0001 * math.MaxFloat64, ts}
+		RandomLargePos0f[i] = tsz.Point{math.Floor(RandomLargePosf[i].V), ts}
+		RandomLarge0f[i] = tsz.Point{math.Floor(RandomLargef[i].V), ts}
+	}
+
 	intervals := []int{10, 30, 60, 120, 360, 720, 1440}
-	do := func(data []testdata.Point) string {
+	do := func(data []tsz.Point) string {
 		str := ""
 		for _, points := range intervals {
 			s := tsz.New(data[0].T)
@@ -61,20 +114,42 @@ func main() {
 	}
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 5, 0, 1, ' ', tabwriter.AlignRight)
+	fmt.Fprintln(w, "=== help ===")
 	fmt.Fprintln(w, "CS = chunk size in Bytes")
-	fmt.Fprintln(w, "BPP = Bytes per point")
+	fmt.Fprintln(w, "BPP = Bytes per point (CS/num-points)")
+	fmt.Fprintln(w, "d = integers stored as float64")
+	fmt.Fprintln(w, "f = float64's with a bunch of decimal numbers")
+	fmt.Fprintln(w, ".Xf = float64's with X decimal numbers")
+	fmt.Fprintln(w, "=== data ===")
 	str := "test"
 	for _, points := range intervals {
 		str += fmt.Sprintf("\t  \033[39m%dCS\033[39m\t%dBPP", points, points)
 	}
 	fmt.Fprintln(w, str)
-	fmt.Fprintf(w, "all zeroes      float\t"+do(DataZeroFloats)+"\n")
-	fmt.Fprintf(w, "all the same    float\t"+do(DataSameFloats)+"\n")
-	fmt.Fprintf(w, "small range pos   int\t"+do(DataSmallRangePosInts)+"\n")
-	fmt.Fprintf(w, "small range pos float\t"+do(DataSmallRangePosFloats)+"\n")
-	fmt.Fprintf(w, "large range pos float\t"+do(DataLargeRangePosFloats)+"\n")
-	fmt.Fprintf(w, "random positive float\t"+do(DataRandomPosFloats)+"\n")
-	fmt.Fprintf(w, "random pos/neg  float\t"+do(DataRandomFloats)+"\n")
+	fmt.Fprintf(w, "constant   zero            d\t"+do(ConstantZero)+"\n")
+	fmt.Fprintf(w, "constant   one             d\t"+do(ConstantOne)+"\n")
+	fmt.Fprintf(w, "constant   pos           .3f\t"+do(ConstantPos3f)+"\n")
+	fmt.Fprintf(w, "constant   neg           .3f\t"+do(ConstantNeg3f)+"\n")
+	fmt.Fprintf(w, "constant   pos           .0f\t"+do(ConstantPos0f)+"\n")
+	fmt.Fprintf(w, "constant   neg           .0f\t"+do(ConstantNeg0f)+"\n")
+	fmt.Fprintf(w, "constant   nearmax         f\t"+do(ConstantNearMaxf)+"\n")
+	fmt.Fprintf(w, "constant   nearmin         f\t"+do(ConstantNearMinf)+"\n")
+	fmt.Fprintf(w, "constant   nearmax       .0f\t"+do(ConstantNearMax0f)+"\n")
+	fmt.Fprintf(w, "constant   nearmin       .0f\t"+do(ConstantNearMin0f)+"\n")
+	fmt.Fprintf(w, "batch100   zero/one        d\t"+do(Batch100ZeroOne)+"\n")
+	fmt.Fprintf(w, "flapping   zero/one        d\t"+do(FlappingZeroOne)+"\n")
+	fmt.Fprintf(w, "pick-range small pos       d\t"+do(SmallRangePosd)+"\n")
+	fmt.Fprintf(w, "pick-range large pos       d\t"+do(LargeRangePosd)+"\n")
+	fmt.Fprintf(w, "pick-range small pos       f\t"+do(SmallRangePosf)+"\n")
+	fmt.Fprintf(w, "pick-range large pos       f\t"+do(LargeRangePosf)+"\n")
+	fmt.Fprintf(w, "pick-range small pos     .0f\t"+do(SmallRangePos0f)+"\n")
+	fmt.Fprintf(w, "pick-range large pos     .0f\t"+do(LargeRangePos0f)+"\n")
+	fmt.Fprintf(w, "pick-rand  small pos       f\t"+do(RandomSmallPosf)+"\n")
+	fmt.Fprintf(w, "pick-rand  small pos/neg   f\t"+do(RandomSmallf)+"\n")
+	fmt.Fprintf(w, "pick-rand  large pos       f\t"+do(RandomLargePosf)+"\n")
+	fmt.Fprintf(w, "pick-rand  large pos/neg   f\t"+do(RandomLargef)+"\n")
+	fmt.Fprintf(w, "pick-rand  large pos     .0f\t"+do(RandomLargePos0f)+"\n")
+	fmt.Fprintf(w, "pick-rand  large pos/neg .0f\t"+do(RandomLarge0f)+"\n")
 	fmt.Fprintln(w)
 	w.Flush()
 }

--- a/eval/main.go
+++ b/eval/main.go
@@ -13,8 +13,6 @@ import (
 // collection of 24h worth of minutely points, with different characteristics.
 var ConstantZero = make([]tsz.Point, 60*24)
 var ConstantOne = make([]tsz.Point, 60*24)
-var Batch100ZeroOne = make([]tsz.Point, 60*24)
-var FlappingZeroOne = make([]tsz.Point, 60*24)
 var ConstantPos3f = make([]tsz.Point, 60*24)
 var ConstantNeg3f = make([]tsz.Point, 60*24)
 var ConstantPos0f = make([]tsz.Point, 60*24)
@@ -23,12 +21,8 @@ var ConstantNearMaxf = make([]tsz.Point, 60*24)
 var ConstantNearMinf = make([]tsz.Point, 60*24)
 var ConstantNearMax0f = make([]tsz.Point, 60*24)
 var ConstantNearMin0f = make([]tsz.Point, 60*24)
-var SmallRangePosd = make([]tsz.Point, 60*24)
-var LargeRangePosd = make([]tsz.Point, 60*24)
-var SmallRangePosf = make([]tsz.Point, 60*24)
-var LargeRangePosf = make([]tsz.Point, 60*24)
-var SmallRangePos0f = make([]tsz.Point, 60*24)
-var LargeRangePos0f = make([]tsz.Point, 60*24)
+var Batch100ZeroOne = make([]tsz.Point, 60*24)
+var FlappingZeroOne = make([]tsz.Point, 60*24)
 
 var RandomTinyPosf = make([]tsz.Point, 60*24)
 var RandomTinyf = make([]tsz.Point, 60*24)
@@ -48,41 +42,33 @@ var RandomSmall1f = make([]tsz.Point, 60*24)
 var RandomSmallPos0f = make([]tsz.Point, 60*24)
 var RandomSmall0f = make([]tsz.Point, 60*24)
 
+var SmallTestDataPosf = make([]tsz.Point, 60*24)
+var SmallTestDataf = make([]tsz.Point, 60*24)
+var SmallTestDataPos0f = make([]tsz.Point, 60*24)
+var SmallTestData0f = make([]tsz.Point, 60*24)
+
 var RandomLargePosf = make([]tsz.Point, 60*24)
 var RandomLargef = make([]tsz.Point, 60*24)
 var RandomLargePos0f = make([]tsz.Point, 60*24)
 var RandomLarge0f = make([]tsz.Point, 60*24)
+var LargeTestDataPosf = make([]tsz.Point, 60*24)
+var LargeTestDataPos0f = make([]tsz.Point, 60*24)
+var LargeTestDataf = make([]tsz.Point, 60*24)
+var LargeTestData0f = make([]tsz.Point, 60*24)
 
-func init() {
-	for i := 0; i < len(DataZeroFloats); i++ {
-		DataZeroFloats[i] = tsz.Point{float64(0), uint32(i * 60)}
-	}
-	for i := 0; i < len(DataSameFloats); i++ {
-		DataSameFloats[i] = tsz.Point{float64(1234.567), uint32(i * 60)}
-	}
-	for i := 0; i < len(DataSmallRangePosInts); i++ {
-		DataSmallRangePosInts[i] = tsz.Point{testdata.TwoHoursData[i%120].V, uint32(i * 60)}
-	}
-	for i := 0; i < len(DataSmallRangePosFloats); i++ {
-		v := float64(testdata.TwoHoursData[i%120].V) * 1.2
-		DataSmallRangePosFloats[i] = tsz.Point{v, uint32(i * 60)}
-	}
-	for i := 0; i < len(DataLargeRangePosFloats); i++ {
-		v := (float64(testdata.TwoHoursData[i%120].V) / 1000) * math.MaxFloat64
-		DataLargeRangePosFloats[i] = tsz.Point{v, uint32(i * 60)}
-	}
-	for i := 0; i < len(DataRandomPosFloats); i++ {
-		DataRandomPosFloats[i] = tsz.Point{rand.ExpFloat64(), uint32(i * 60)}
-	}
-	for i := 0; i < len(DataRandomFloats); i++ {
-		DataRandomFloats[i] = tsz.Point{rand.NormFloat64(), uint32(i * 60)}
-	}
-}
 func main() {
 	for i := 0; i < 60*24; i++ {
 		ts := uint32(i * 60)
 		ConstantZero[i] = tsz.Point{float64(0), ts}
 		ConstantOne[i] = tsz.Point{float64(1), ts}
+		ConstantPos3f[i] = tsz.Point{float64(1234.567), ts}
+		ConstantNeg3f[i] = tsz.Point{float64(-1234.567), ts}
+		ConstantPos0f[i] = tsz.Point{float64(1234), ts}
+		ConstantNeg0f[i] = tsz.Point{float64(-1235), ts}
+		ConstantNearMaxf[i] = tsz.Point{math.MaxFloat64 / 100, ts}
+		ConstantNearMinf[i] = tsz.Point{-math.MaxFloat64 / 100, ts}
+		ConstantNearMax0f[i] = tsz.Point{math.Floor(ConstantNearMaxf[i].V), ts}
+		ConstantNearMin0f[i] = tsz.Point{math.Floor(ConstantNearMinf[i].V), ts}
 		if i%200 < 100 {
 			Batch100ZeroOne[i] = tsz.Point{float64(0), ts}
 		} else {
@@ -93,21 +79,6 @@ func main() {
 		} else {
 			FlappingZeroOne[i] = tsz.Point{float64(1), ts}
 		}
-		ConstantPos3f[i] = tsz.Point{float64(1234.567), ts}
-		ConstantNeg3f[i] = tsz.Point{float64(-1234.567), ts}
-		ConstantPos0f[i] = tsz.Point{float64(1234), ts}
-		ConstantNeg0f[i] = tsz.Point{float64(-1235), ts}
-		ConstantNearMaxf[i] = tsz.Point{math.MaxFloat64 / 100, ts}
-		ConstantNearMinf[i] = tsz.Point{-math.MaxFloat64 / 100, ts}
-		ConstantNearMax0f[i] = tsz.Point{math.Floor(ConstantNearMaxf[i].V), ts}
-		ConstantNearMin0f[i] = tsz.Point{math.Floor(ConstantNearMinf[i].V), ts}
-
-		SmallRangePosd[i] = tsz.Point{testdata.TwoHoursData[i%120].V, ts}                                            // THD is 650 - 860, so this is 0-119
-		LargeRangePosd[i] = tsz.Point{testdata.TwoHoursData[i%120].V * 1000000, ts}                                  // 0 to 119M
-		SmallRangePosf[i] = tsz.Point{float64(testdata.TwoHoursData[i%120].V) * 1.234567, ts}                        // 0-150
-		LargeRangePosf[i] = tsz.Point{float64(testdata.TwoHoursData[i%120].V) * 0.00001234567 * math.MaxFloat64, ts} // 0-maxfloat/1000
-		SmallRangePos0f[i] = tsz.Point{math.Floor(SmallRangePosf[i].V), ts}                                          // 0-150
-		LargeRangePos0f[i] = tsz.Point{math.Floor(LargeRangePosf[i].V), ts}                                          // 0-maxfloat/1000
 
 		RandomTinyPosf[i] = tsz.Point{rand.ExpFloat64(), ts} // 0-inf, but most vals are very low, mostly between 0 and 2, rarely goes over 10
 		RandomTinyf[i] = tsz.Point{rand.NormFloat64(), ts}   // -inf to + inf, as many pos as neg, but similar as above, rarely goes under -10 or over +10
@@ -127,14 +98,33 @@ func main() {
 		RandomSmallPos0f[i] = tsz.Point{math.Floor(RandomSmallPosf[i].V), ts}
 		RandomSmall0f[i] = tsz.Point{math.Floor(RandomSmallPosf[i].V), ts}
 
+		SmallTestDataPosf[i] = tsz.Point{float64(tsz.TwoHoursData[i%120].V) * 1.234567, ts} // THD is 650-680, so this is 0-150
+		if rand.Int()%2 == 0 {
+			SmallTestDataf[i] = tsz.Point{SmallTestDataPosf[i].V, ts} // -150 - 150
+		} else {
+			SmallTestDataf[i] = tsz.Point{-1 * SmallTestDataPosf[i].V, ts}
+		}
+		SmallTestDataPos0f[i] = tsz.Point{math.Floor(SmallTestDataPosf[i].V), ts} // 0-150
+		SmallTestData0f[i] = tsz.Point{math.Floor(SmallTestDataf[i].V), ts}       // -150 - 150
+
 		RandomLargePosf[i] = tsz.Point{rand.ExpFloat64() * 0.0001 * math.MaxFloat64, ts} // 0-inf, rarely goes over maxfloat/1000
 		RandomLargef[i] = tsz.Point{rand.NormFloat64() * 0.0001 * math.MaxFloat64, ts}   // same buth also negative
 		RandomLargePos0f[i] = tsz.Point{math.Floor(RandomLargePosf[i].V), ts}
 		RandomLarge0f[i] = tsz.Point{math.Floor(RandomLargef[i].V), ts}
+
+		LargeTestDataPosf[i] = tsz.Point{float64(tsz.TwoHoursData[i%120].V) * 0.00001234567 * math.MaxFloat64, ts} // 0-maxfloat/1000
+		if rand.Int()%2 == 0 {
+			LargeTestDataf[i] = tsz.Point{LargeTestDataPosf[i].V, ts} // -maxfloat/1000 ~maxfloat/1000
+		} else {
+			LargeTestDataf[i] = tsz.Point{-1 * LargeTestDataPosf[i].V, ts}
+		}
+
+		LargeTestDataPos0f[i] = tsz.Point{math.Floor(LargeTestDataPosf[i].V), ts} // 0-maxfloat/1000
+		LargeTestData0f[i] = tsz.Point{math.Floor(LargeTestDataf[i].V), ts}       // -mf/1000 ~ mx/1000
 	}
 
 	intervals := []int{10, 30, 60, 120, 360, 720, 1440}
-	do := func(data []tsz.Point) string {
+	do := func(data []tsz.Point, comment string) string {
 		str := ""
 		for _, points := range intervals {
 			s := tsz.New(data[0].T)
@@ -145,63 +135,77 @@ func main() {
 			BPerPoint := float64(size) / float64(points)
 			str += fmt.Sprintf("\033[31m%d\033[39m\t%.2f\t", size, BPerPoint)
 		}
+		str += comment + "\t"
 		return str
 	}
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 5, 0, 1, ' ', tabwriter.AlignRight)
-	fmt.Fprintln(w, "=== help ===")
-	fmt.Fprintln(w, "CS = chunk size in Bytes")
-	fmt.Fprintln(w, "BPP = Bytes per point (CS/num-points)")
-	fmt.Fprintln(w, "d = integers stored as float64")
-	fmt.Fprintln(w, "f = float64's with a bunch of decimal numbers")
-	fmt.Fprintln(w, ".Xf = float64's with X decimal numbers")
-	fmt.Fprintln(w, "=== data ===")
+	fmt.Println("=== help ===")
+	fmt.Println("CS = chunk size in Bytes")
+	fmt.Println("BPP = Bytes per point (CS/num-points)")
+	fmt.Println("d = integers stored as float64")
+	fmt.Println("f = float64's with a bunch of decimal numbers")
+	fmt.Println(".Xf = float64's with X decimal numbers")
+	fmt.Println("=== data ===")
 	str := "test"
 	for _, points := range intervals {
 		str += fmt.Sprintf("\t  \033[39m%dCS\033[39m\t%dBPP", points, points)
 	}
-	fmt.Fprintln(w, str)
-	fmt.Fprintf(w, "constant   zero            d\t"+do(ConstantZero)+"\n")
-	fmt.Fprintf(w, "constant   one             d\t"+do(ConstantOne)+"\n")
-	fmt.Fprintf(w, "constant   pos           .3f\t"+do(ConstantPos3f)+"\n")
-	fmt.Fprintf(w, "constant   neg           .3f\t"+do(ConstantNeg3f)+"\n")
-	fmt.Fprintf(w, "constant   pos           .0f\t"+do(ConstantPos0f)+"\n")
-	fmt.Fprintf(w, "constant   neg           .0f\t"+do(ConstantNeg0f)+"\n")
-	fmt.Fprintf(w, "constant   nearmax         f\t"+do(ConstantNearMaxf)+"\n")
-	fmt.Fprintf(w, "constant   nearmin         f\t"+do(ConstantNearMinf)+"\n")
-	fmt.Fprintf(w, "constant   nearmax       .0f\t"+do(ConstantNearMax0f)+"\n")
-	fmt.Fprintf(w, "constant   nearmin       .0f\t"+do(ConstantNearMin0f)+"\n")
-	fmt.Fprintf(w, "batch100   zero/one        d\t"+do(Batch100ZeroOne)+"\n")
-	fmt.Fprintf(w, "flapping   zero/one        d\t"+do(FlappingZeroOne)+"\n")
-	fmt.Fprintf(w, "pick-range small pos       d\t"+do(SmallRangePosd)+"\n")
-	fmt.Fprintf(w, "pick-range large pos       d\t"+do(LargeRangePosd)+"\n")
-	fmt.Fprintf(w, "pick-range small pos       f\t"+do(SmallRangePosf)+"\n")
-	fmt.Fprintf(w, "pick-range large pos       f\t"+do(LargeRangePosf)+"\n")
-	fmt.Fprintf(w, "pick-range small pos     .0f\t"+do(SmallRangePos0f)+"\n")
-	fmt.Fprintf(w, "pick-range large pos     .0f\t"+do(LargeRangePos0f)+"\n")
-	fmt.Fprintf(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n")
-	fmt.Fprintf(w, "pick-rand  tiny  pos       f\t"+do(RandomTinyPosf)+"\n")
-	fmt.Fprintf(w, "pick-rand  tiny  pos/neg   f\t"+do(RandomTinyf)+"\n")
-	fmt.Fprintf(w, "pick-rand  tiny  pos     .2f\t"+do(RandomTinyPos2f)+"\n")
-	fmt.Fprintf(w, "pick-rand  tiny  pos/neg .2f\t"+do(RandomTiny2f)+"\n")
-	fmt.Fprintf(w, "pick-rand  tiny  pos     .1f\t"+do(RandomTinyPos1f)+"\n")
-	fmt.Fprintf(w, "pick-rand  tiny  pos/neg .1f\t"+do(RandomTiny1f)+"\n")
-	fmt.Fprintf(w, "pick-rand  tiny  pos     .0f\t"+do(RandomTinyPos0f)+"\n")
-	fmt.Fprintf(w, "pick-rand  tiny  pos/neg .0f\t"+do(RandomTiny0f)+"\n")
-	fmt.Fprintf(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n")
-	fmt.Fprintf(w, "pick-rand  small pos       f\t"+do(RandomSmallPosf)+"\n")
-	fmt.Fprintf(w, "pick-rand  small pos/neg   f\t"+do(RandomSmallf)+"\n")
-	fmt.Fprintf(w, "pick-rand  small pos     .2f\t"+do(RandomSmallPos2f)+"\n")
-	fmt.Fprintf(w, "pick-rand  small pos/neg .2f\t"+do(RandomSmall2f)+"\n")
-	fmt.Fprintf(w, "pick-rand  small pos     .1f\t"+do(RandomSmallPos1f)+"\n")
-	fmt.Fprintf(w, "pick-rand  small pos/neg .1f\t"+do(RandomSmall1f)+"\n")
-	fmt.Fprintf(w, "pick-rand  small pos     .0f\t"+do(RandomSmallPos0f)+"\n")
-	fmt.Fprintf(w, "pick-rand  small pos/neg .0f\t"+do(RandomSmall0f)+"\n")
-	fmt.Fprintf(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n")
-	fmt.Fprintf(w, "pick-rand  large pos       f\t"+do(RandomLargePosf)+"\n")
-	fmt.Fprintf(w, "pick-rand  large pos/neg   f\t"+do(RandomLargef)+"\n")
-	fmt.Fprintf(w, "pick-rand  large pos     .0f\t"+do(RandomLargePos0f)+"\n")
-	fmt.Fprintf(w, "pick-rand  large pos/neg .0f\t"+do(RandomLarge0f)+"\n")
-	fmt.Fprintln(w)
+	cmtTinyPos := "0 ~ 10 [inf]"
+	cmtTinyPosNeg := "[-inf] -10 ~ 10 [inf]"
+	cmtSmallPos := "0 ~ 1000 [inf]"
+	cmtSmallPosNeg := "[-inf] -1000 ~ 1000 [inf]"
+	cmtSmallTestPos := "0~150"
+	cmtSmallTestPosNeg := "-150~150"
+	cmtRandomLargePos := "0 ~ MaxFloat64/1000 [inf]"
+	cmtRandomLargePosNeg := "[-inf] -MaxFloat64/1000 ~ MaxFloat64/1000 [inf]"
+	cmtLargeTestPos := "0 ~ MaxFloat64/1000"
+	cmtLargeTestPosNeg := "-MaxFloat64/1000 ~ MaxFloat64/1000"
+	fmt.Fprintln(w, str+"\tcomment\t")
+	fmt.Fprintln(w, "constant zero            d\t"+do(ConstantZero, ""))
+	fmt.Fprintln(w, "constant one             d\t"+do(ConstantOne, ""))
+	fmt.Fprintln(w, "constant pos           .3f\t"+do(ConstantPos3f, ""))
+	fmt.Fprintln(w, "constant neg           .3f\t"+do(ConstantNeg3f, ""))
+	fmt.Fprintln(w, "constant pos           .0f\t"+do(ConstantPos0f, ""))
+	fmt.Fprintln(w, "constant neg           .0f\t"+do(ConstantNeg0f, ""))
+	fmt.Fprintln(w, "constant nearmax         f\t"+do(ConstantNearMaxf, ""))
+	fmt.Fprintln(w, "constant nearmin         f\t"+do(ConstantNearMinf, ""))
+	fmt.Fprintln(w, "constant nearmax       .0f\t"+do(ConstantNearMax0f, ""))
+	fmt.Fprintln(w, "constant nearmin       .0f\t"+do(ConstantNearMin0f, ""))
+	fmt.Fprintln(w, "batch100 zero/one        d\t"+do(Batch100ZeroOne, ""))
+	fmt.Fprintln(w, "flapping zero/one        d\t"+do(FlappingZeroOne, ""))
+	fmt.Fprintln(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t")
+	fmt.Fprintln(w, "random tiny pos       f\t"+do(RandomTinyPosf, cmtTinyPos))
+	fmt.Fprintln(w, "random tiny pos/neg   f\t"+do(RandomTinyf, cmtTinyPosNeg))
+	fmt.Fprintln(w, "random tiny pos     .2f\t"+do(RandomTinyPos2f, cmtTinyPos))
+	fmt.Fprintln(w, "random tiny pos/neg .2f\t"+do(RandomTiny2f, cmtTinyPosNeg))
+	fmt.Fprintln(w, "random tiny pos     .1f\t"+do(RandomTinyPos1f, cmtTinyPos))
+	fmt.Fprintln(w, "random tiny pos/neg .1f\t"+do(RandomTiny1f, cmtTinyPosNeg))
+	fmt.Fprintln(w, "random tiny pos     .0f\t"+do(RandomTinyPos0f, cmtTinyPos))
+	fmt.Fprintln(w, "random tiny pos/neg .0f\t"+do(RandomTiny0f, cmtTinyPosNeg))
+	fmt.Fprintln(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t")
+	fmt.Fprintln(w, "random small pos        f\t"+do(RandomSmallPosf, cmtSmallPos))
+	fmt.Fprintln(w, "random small pos/neg    f\t"+do(RandomSmallf, cmtSmallPosNeg))
+	fmt.Fprintln(w, "random small pos      .2f\t"+do(RandomSmallPos2f, cmtSmallPos))
+	fmt.Fprintln(w, "random small pos/neg  .2f\t"+do(RandomSmall2f, cmtSmallPosNeg))
+	fmt.Fprintln(w, "random small pos      .1f\t"+do(RandomSmallPos1f, cmtSmallPos))
+	fmt.Fprintln(w, "random small pos/neg  .1f\t"+do(RandomSmall1f, cmtSmallPosNeg))
+	fmt.Fprintln(w, "random small pos      .0f\t"+do(RandomSmallPos0f, cmtSmallPos))
+	fmt.Fprintln(w, "random small pos/neg  .0f\t"+do(RandomSmall0f, cmtSmallPosNeg))
+	fmt.Fprintln(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t")
+	fmt.Fprintln(w, "testdata small pos       f\t"+do(SmallTestDataPosf, cmtSmallTestPos))
+	fmt.Fprintln(w, "testdata small pos/neg   f\t"+do(SmallTestDataf, cmtSmallTestPosNeg))
+	fmt.Fprintln(w, "testdata small pos     .0f\t"+do(SmallTestDataPos0f, cmtSmallTestPos))
+	fmt.Fprintln(w, "testdata small pos/neg .0f\t"+do(SmallTestData0f, cmtSmallTestPosNeg))
+	fmt.Fprintln(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t")
+	fmt.Fprintln(w, "random large pos        f\t"+do(RandomLargePosf, cmtRandomLargePos))
+	fmt.Fprintln(w, "random large pos/neg    f\t"+do(RandomLargef, cmtRandomLargePosNeg))
+	fmt.Fprintln(w, "random large pos      .0f\t"+do(RandomLargePos0f, cmtRandomLargePos))
+	fmt.Fprintln(w, "random large pos/neg  .0f\t"+do(RandomLarge0f, cmtRandomLargePosNeg))
+	fmt.Fprintln(w, "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t")
+	fmt.Fprintln(w, "testdata large pos       f\t"+do(LargeTestDataPosf, cmtLargeTestPos))
+	fmt.Fprintln(w, "testdata large pos/neg   f\t"+do(LargeTestDataf, cmtLargeTestPosNeg))
+	fmt.Fprintln(w, "testdata large pos     .0f\t"+do(LargeTestDataPos0f, cmtLargeTestPos))
+	fmt.Fprintln(w, "testdata large pos/neg .0f\t"+do(LargeTestData0f, cmtLargeTestPosNeg))
 	w.Flush()
 }

--- a/eval/main.go
+++ b/eval/main.go
@@ -11,120 +11,120 @@ import (
 )
 
 // collection of 24h worth of minutely points, with different characteristics.
-var ConstantZero = make([]tsz.Point, 60*24)
-var ConstantOne = make([]tsz.Point, 60*24)
-var ConstantPos3f = make([]tsz.Point, 60*24)
-var ConstantNeg3f = make([]tsz.Point, 60*24)
-var ConstantPos0f = make([]tsz.Point, 60*24)
-var ConstantNeg0f = make([]tsz.Point, 60*24)
-var ConstantNearMaxf = make([]tsz.Point, 60*24)
-var ConstantNearMinf = make([]tsz.Point, 60*24)
-var ConstantNearMax0f = make([]tsz.Point, 60*24)
-var ConstantNearMin0f = make([]tsz.Point, 60*24)
-var Batch100ZeroOne = make([]tsz.Point, 60*24)
-var FlappingZeroOne = make([]tsz.Point, 60*24)
+var ConstantZero = make([]testdata.Point, 60*24)
+var ConstantOne = make([]testdata.Point, 60*24)
+var ConstantPos3f = make([]testdata.Point, 60*24)
+var ConstantNeg3f = make([]testdata.Point, 60*24)
+var ConstantPos0f = make([]testdata.Point, 60*24)
+var ConstantNeg0f = make([]testdata.Point, 60*24)
+var ConstantNearMaxf = make([]testdata.Point, 60*24)
+var ConstantNearMinf = make([]testdata.Point, 60*24)
+var ConstantNearMax0f = make([]testdata.Point, 60*24)
+var ConstantNearMin0f = make([]testdata.Point, 60*24)
+var Batch100ZeroOne = make([]testdata.Point, 60*24)
+var FlappingZeroOne = make([]testdata.Point, 60*24)
 
-var RandomTinyPosf = make([]tsz.Point, 60*24)
-var RandomTinyf = make([]tsz.Point, 60*24)
-var RandomTinyPos2f = make([]tsz.Point, 60*24)
-var RandomTiny2f = make([]tsz.Point, 60*24)
-var RandomTinyPos1f = make([]tsz.Point, 60*24)
-var RandomTiny1f = make([]tsz.Point, 60*24)
-var RandomTinyPos0f = make([]tsz.Point, 60*24)
-var RandomTiny0f = make([]tsz.Point, 60*24)
+var RandomTinyPosf = make([]testdata.Point, 60*24)
+var RandomTinyf = make([]testdata.Point, 60*24)
+var RandomTinyPos2f = make([]testdata.Point, 60*24)
+var RandomTiny2f = make([]testdata.Point, 60*24)
+var RandomTinyPos1f = make([]testdata.Point, 60*24)
+var RandomTiny1f = make([]testdata.Point, 60*24)
+var RandomTinyPos0f = make([]testdata.Point, 60*24)
+var RandomTiny0f = make([]testdata.Point, 60*24)
 
-var RandomSmallPosf = make([]tsz.Point, 60*24)
-var RandomSmallf = make([]tsz.Point, 60*24)
-var RandomSmallPos2f = make([]tsz.Point, 60*24)
-var RandomSmall2f = make([]tsz.Point, 60*24)
-var RandomSmallPos1f = make([]tsz.Point, 60*24)
-var RandomSmall1f = make([]tsz.Point, 60*24)
-var RandomSmallPos0f = make([]tsz.Point, 60*24)
-var RandomSmall0f = make([]tsz.Point, 60*24)
+var RandomSmallPosf = make([]testdata.Point, 60*24)
+var RandomSmallf = make([]testdata.Point, 60*24)
+var RandomSmallPos2f = make([]testdata.Point, 60*24)
+var RandomSmall2f = make([]testdata.Point, 60*24)
+var RandomSmallPos1f = make([]testdata.Point, 60*24)
+var RandomSmall1f = make([]testdata.Point, 60*24)
+var RandomSmallPos0f = make([]testdata.Point, 60*24)
+var RandomSmall0f = make([]testdata.Point, 60*24)
 
-var SmallTestDataPosf = make([]tsz.Point, 60*24)
-var SmallTestDataf = make([]tsz.Point, 60*24)
-var SmallTestDataPos0f = make([]tsz.Point, 60*24)
-var SmallTestData0f = make([]tsz.Point, 60*24)
+var SmallTestDataPosf = make([]testdata.Point, 60*24)
+var SmallTestDataf = make([]testdata.Point, 60*24)
+var SmallTestDataPos0f = make([]testdata.Point, 60*24)
+var SmallTestData0f = make([]testdata.Point, 60*24)
 
-var RandomLargePosf = make([]tsz.Point, 60*24)
-var RandomLargef = make([]tsz.Point, 60*24)
-var RandomLargePos0f = make([]tsz.Point, 60*24)
-var RandomLarge0f = make([]tsz.Point, 60*24)
-var LargeTestDataPosf = make([]tsz.Point, 60*24)
-var LargeTestDataPos0f = make([]tsz.Point, 60*24)
-var LargeTestDataf = make([]tsz.Point, 60*24)
-var LargeTestData0f = make([]tsz.Point, 60*24)
+var RandomLargePosf = make([]testdata.Point, 60*24)
+var RandomLargef = make([]testdata.Point, 60*24)
+var RandomLargePos0f = make([]testdata.Point, 60*24)
+var RandomLarge0f = make([]testdata.Point, 60*24)
+var LargeTestDataPosf = make([]testdata.Point, 60*24)
+var LargeTestDataPos0f = make([]testdata.Point, 60*24)
+var LargeTestDataf = make([]testdata.Point, 60*24)
+var LargeTestData0f = make([]testdata.Point, 60*24)
 
 func main() {
 	for i := 0; i < 60*24; i++ {
 		ts := uint32(i * 60)
-		ConstantZero[i] = tsz.Point{float64(0), ts}
-		ConstantOne[i] = tsz.Point{float64(1), ts}
-		ConstantPos3f[i] = tsz.Point{float64(1234.567), ts}
-		ConstantNeg3f[i] = tsz.Point{float64(-1234.567), ts}
-		ConstantPos0f[i] = tsz.Point{float64(1234), ts}
-		ConstantNeg0f[i] = tsz.Point{float64(-1235), ts}
-		ConstantNearMaxf[i] = tsz.Point{math.MaxFloat64 / 100, ts}
-		ConstantNearMinf[i] = tsz.Point{-math.MaxFloat64 / 100, ts}
-		ConstantNearMax0f[i] = tsz.Point{math.Floor(ConstantNearMaxf[i].V), ts}
-		ConstantNearMin0f[i] = tsz.Point{math.Floor(ConstantNearMinf[i].V), ts}
+		ConstantZero[i] = testdata.Point{float64(0), ts}
+		ConstantOne[i] = testdata.Point{float64(1), ts}
+		ConstantPos3f[i] = testdata.Point{float64(1234.567), ts}
+		ConstantNeg3f[i] = testdata.Point{float64(-1234.567), ts}
+		ConstantPos0f[i] = testdata.Point{float64(1234), ts}
+		ConstantNeg0f[i] = testdata.Point{float64(-1235), ts}
+		ConstantNearMaxf[i] = testdata.Point{math.MaxFloat64 / 100, ts}
+		ConstantNearMinf[i] = testdata.Point{-math.MaxFloat64 / 100, ts}
+		ConstantNearMax0f[i] = testdata.Point{math.Floor(ConstantNearMaxf[i].V), ts}
+		ConstantNearMin0f[i] = testdata.Point{math.Floor(ConstantNearMinf[i].V), ts}
 		if i%200 < 100 {
-			Batch100ZeroOne[i] = tsz.Point{float64(0), ts}
+			Batch100ZeroOne[i] = testdata.Point{float64(0), ts}
 		} else {
-			Batch100ZeroOne[i] = tsz.Point{float64(1), ts}
+			Batch100ZeroOne[i] = testdata.Point{float64(1), ts}
 		}
 		if i%2 == 0 {
-			FlappingZeroOne[i] = tsz.Point{float64(0), ts}
+			FlappingZeroOne[i] = testdata.Point{float64(0), ts}
 		} else {
-			FlappingZeroOne[i] = tsz.Point{float64(1), ts}
+			FlappingZeroOne[i] = testdata.Point{float64(1), ts}
 		}
 
-		RandomTinyPosf[i] = tsz.Point{rand.ExpFloat64(), ts} // 0-inf, but most vals are very low, mostly between 0 and 2, rarely goes over 10
-		RandomTinyf[i] = tsz.Point{rand.NormFloat64(), ts}   // -inf to + inf, as many pos as neg, but similar as above, rarely goes under -10 or over +10
-		RandomTinyPos2f[i] = tsz.Point{RoundNum(RandomTinyPosf[i].V, 2), ts}
-		RandomTiny2f[i] = tsz.Point{RoundNum(RandomTinyPosf[i].V, 2), ts}
-		RandomTinyPos1f[i] = tsz.Point{RoundNum(RandomTinyPosf[i].V, 1), ts}
-		RandomTiny1f[i] = tsz.Point{RoundNum(RandomTinyPosf[i].V, 1), ts}
-		RandomTinyPos0f[i] = tsz.Point{math.Floor(RandomTinyPosf[i].V), ts}
-		RandomTiny0f[i] = tsz.Point{math.Floor(RandomTinyPosf[i].V), ts}
+		RandomTinyPosf[i] = testdata.Point{rand.ExpFloat64(), ts} // 0-inf, but most vals are very low, mostly between 0 and 2, rarely goes over 10
+		RandomTinyf[i] = testdata.Point{rand.NormFloat64(), ts}   // -inf to + inf, as many pos as neg, but similar as above, rarely goes under -10 or over +10
+		RandomTinyPos2f[i] = testdata.Point{RoundNum(RandomTinyPosf[i].V, 2), ts}
+		RandomTiny2f[i] = testdata.Point{RoundNum(RandomTinyPosf[i].V, 2), ts}
+		RandomTinyPos1f[i] = testdata.Point{RoundNum(RandomTinyPosf[i].V, 1), ts}
+		RandomTiny1f[i] = testdata.Point{RoundNum(RandomTinyPosf[i].V, 1), ts}
+		RandomTinyPos0f[i] = testdata.Point{math.Floor(RandomTinyPosf[i].V), ts}
+		RandomTiny0f[i] = testdata.Point{math.Floor(RandomTinyPosf[i].V), ts}
 
-		RandomSmallPosf[i] = tsz.Point{RandomTinyPosf[i].V * 100, ts} // 0-inf, but most vals are very low, mostly between 0 and 200, rarely goes over 1000
-		RandomSmallf[i] = tsz.Point{RandomTinyf[i].V * 100, ts}       // -inf to + inf, as many pos as neg, but similar as above, rarely goes under -1000 or over +1000
-		RandomSmallPos2f[i] = tsz.Point{RoundNum(RandomSmallPosf[i].V, 2), ts}
-		RandomSmall2f[i] = tsz.Point{RoundNum(RandomSmallPosf[i].V, 2), ts}
-		RandomSmallPos1f[i] = tsz.Point{RoundNum(RandomSmallPosf[i].V, 1), ts}
-		RandomSmall1f[i] = tsz.Point{RoundNum(RandomSmallPosf[i].V, 1), ts}
-		RandomSmallPos0f[i] = tsz.Point{math.Floor(RandomSmallPosf[i].V), ts}
-		RandomSmall0f[i] = tsz.Point{math.Floor(RandomSmallPosf[i].V), ts}
+		RandomSmallPosf[i] = testdata.Point{RandomTinyPosf[i].V * 100, ts} // 0-inf, but most vals are very low, mostly between 0 and 200, rarely goes over 1000
+		RandomSmallf[i] = testdata.Point{RandomTinyf[i].V * 100, ts}       // -inf to + inf, as many pos as neg, but similar as above, rarely goes under -1000 or over +1000
+		RandomSmallPos2f[i] = testdata.Point{RoundNum(RandomSmallPosf[i].V, 2), ts}
+		RandomSmall2f[i] = testdata.Point{RoundNum(RandomSmallPosf[i].V, 2), ts}
+		RandomSmallPos1f[i] = testdata.Point{RoundNum(RandomSmallPosf[i].V, 1), ts}
+		RandomSmall1f[i] = testdata.Point{RoundNum(RandomSmallPosf[i].V, 1), ts}
+		RandomSmallPos0f[i] = testdata.Point{math.Floor(RandomSmallPosf[i].V), ts}
+		RandomSmall0f[i] = testdata.Point{math.Floor(RandomSmallPosf[i].V), ts}
 
-		SmallTestDataPosf[i] = tsz.Point{float64(tsz.TwoHoursData[i%120].V) * 1.234567, ts} // THD is 650-680, so this is 0-150
+		SmallTestDataPosf[i] = testdata.Point{float64(testdata.TwoHoursData[i%120].V) * 1.234567, ts} // THD is 650-680, so this is 0-150
 		if rand.Int()%2 == 0 {
-			SmallTestDataf[i] = tsz.Point{SmallTestDataPosf[i].V, ts} // -150 - 150
+			SmallTestDataf[i] = testdata.Point{SmallTestDataPosf[i].V, ts} // -150 - 150
 		} else {
-			SmallTestDataf[i] = tsz.Point{-1 * SmallTestDataPosf[i].V, ts}
+			SmallTestDataf[i] = testdata.Point{-1 * SmallTestDataPosf[i].V, ts}
 		}
-		SmallTestDataPos0f[i] = tsz.Point{math.Floor(SmallTestDataPosf[i].V), ts} // 0-150
-		SmallTestData0f[i] = tsz.Point{math.Floor(SmallTestDataf[i].V), ts}       // -150 - 150
+		SmallTestDataPos0f[i] = testdata.Point{math.Floor(SmallTestDataPosf[i].V), ts} // 0-150
+		SmallTestData0f[i] = testdata.Point{math.Floor(SmallTestDataf[i].V), ts}       // -150 - 150
 
-		RandomLargePosf[i] = tsz.Point{rand.ExpFloat64() * 0.0001 * math.MaxFloat64, ts} // 0-inf, rarely goes over maxfloat/1000
-		RandomLargef[i] = tsz.Point{rand.NormFloat64() * 0.0001 * math.MaxFloat64, ts}   // same buth also negative
-		RandomLargePos0f[i] = tsz.Point{math.Floor(RandomLargePosf[i].V), ts}
-		RandomLarge0f[i] = tsz.Point{math.Floor(RandomLargef[i].V), ts}
+		RandomLargePosf[i] = testdata.Point{rand.ExpFloat64() * 0.0001 * math.MaxFloat64, ts} // 0-inf, rarely goes over maxfloat/1000
+		RandomLargef[i] = testdata.Point{rand.NormFloat64() * 0.0001 * math.MaxFloat64, ts}   // same buth also negative
+		RandomLargePos0f[i] = testdata.Point{math.Floor(RandomLargePosf[i].V), ts}
+		RandomLarge0f[i] = testdata.Point{math.Floor(RandomLargef[i].V), ts}
 
-		LargeTestDataPosf[i] = tsz.Point{float64(tsz.TwoHoursData[i%120].V) * 0.00001234567 * math.MaxFloat64, ts} // 0-maxfloat/1000
+		LargeTestDataPosf[i] = testdata.Point{float64(testdata.TwoHoursData[i%120].V) * 0.00001234567 * math.MaxFloat64, ts} // 0-maxfloat/1000
 		if rand.Int()%2 == 0 {
-			LargeTestDataf[i] = tsz.Point{LargeTestDataPosf[i].V, ts} // -maxfloat/1000 ~maxfloat/1000
+			LargeTestDataf[i] = testdata.Point{LargeTestDataPosf[i].V, ts} // -maxfloat/1000 ~maxfloat/1000
 		} else {
-			LargeTestDataf[i] = tsz.Point{-1 * LargeTestDataPosf[i].V, ts}
+			LargeTestDataf[i] = testdata.Point{-1 * LargeTestDataPosf[i].V, ts}
 		}
 
-		LargeTestDataPos0f[i] = tsz.Point{math.Floor(LargeTestDataPosf[i].V), ts} // 0-maxfloat/1000
-		LargeTestData0f[i] = tsz.Point{math.Floor(LargeTestDataf[i].V), ts}       // -mf/1000 ~ mx/1000
+		LargeTestDataPos0f[i] = testdata.Point{math.Floor(LargeTestDataPosf[i].V), ts} // 0-maxfloat/1000
+		LargeTestData0f[i] = testdata.Point{math.Floor(LargeTestDataf[i].V), ts}       // -mf/1000 ~ mx/1000
 	}
 
 	intervals := []int{10, 30, 60, 120, 360, 720, 1440}
-	do := func(data []tsz.Point, comment string) string {
+	do := func(data []testdata.Point, comment string) string {
 		str := ""
 		for _, points := range intervals {
 			s := tsz.New(data[0].T)


### PR DESCRIPTION
I will rebase this branch once #8 is merged, to get the better location for the test data,
but that's just a code detail and doesn't hold back from sharing these results.
I wanted to share these results and invite @dgryski and @woodsaj and @nopzor to have a closer look

here's my updated conclusions:

* high compression seems only achievable in special cases like equal values, lack of decimals. In "real, noisy" float scenarios, compression is marginal.
* equal values compress very well, and it doesn't seem to matter what the actual value is.
* rounding down to limit the number of decimals can help a little bit, but rounding to 0 decimals can help a lot, especially for small numbers, the gain can be 6x.
* for large numbers however, rounding down the decimals doesn't seem to help at all.
* numbers that don't compress well, will get no benefit of larger chunks. numbers that compress well do benefit from larger chunks, multiplying their gains.
* chunk size only matters for values that compress well, and there, around 120 points seems like the sweet spot (like the paper said). 
* mixed signs (+-) add a 10x overhead, but this disappears as soon as we limit the number of decimals

screenshot of output:
![conclusions](https://cloud.githubusercontent.com/assets/20774/11618424/4a99008e-9cff-11e5-8ad4-d39fe62ae77b.png)