### PR TITLE
show MB/s data rate in encoding & decoding benchmarks

### DIFF
--- a/tsz_test.go
+++ b/tsz_test.go
@@ -185,6 +185,7 @@ func testConcurrentRoundtrip(t *testing.T, sleep time.Duration) {
 }
 
 func BenchmarkEncode(b *testing.B) {
+	b.SetBytes(int64(len(testdata.TwoHoursData) * 12))
 	for i := 0; i < b.N; i++ {
 		s := New(testdata.TwoHoursData[0].T)
 		for _, tt := range testdata.TwoHoursData {
@@ -194,6 +195,7 @@ func BenchmarkEncode(b *testing.B) {
 }
 
 func BenchmarkDecode(b *testing.B) {
+	b.SetBytes(int64(len(testdata.TwoHoursData) * 12))
 	s := New(testdata.TwoHoursData[0].T)
 	for _, tt := range testdata.TwoHoursData {
 		s.Push(tt.T, tt.V)


### PR DESCRIPTION
```
$ go test -run=XX -bench=. -benchmem -v
PASS
BenchmarkEncode-8	  100000	     19643 ns/op	  73.31 MB/s	     568 B/op	       7 allocs/op
BenchmarkDecode-8	  200000	      7478 ns/op	 192.54 MB/s	     704 B/op	       3 allocs/op
ok  	github.com/dgryski/go-tsz	3.756s
```

I didn't realize until recently that decoding (and encoding) is so expensive.
for comparison, in metric-tank - after some optimisations - data consolidation works at 2~6GB/s and json encoding is around 50 MB/s (luckily this is post-consolidation)

@dgryski can you have a look and see if there's any way to make decoding faster? here's a screenshot of a profile I took the other day: http://i.imgur.com/7tTIFHd.png readBits and readByte seem to be a bottleneck for us. thanks