### PR TITLE
Use golang math/bits leading & trailing zero count functions

### DIFF
--- a/tsz.go
+++ b/tsz.go
@@ -11,9 +11,8 @@ import (
 	"encoding/binary"
 	"io"
 	"math"
+	"math/bits"
 	"sync"
-
-	"github.com/dgryski/go-bits"
 )
 
 // Series is the basic series primitive
@@ -114,8 +113,8 @@ func (s *Series) Push(t uint32, v float64) {
 	} else {
 		s.bw.writeBit(one)
 
-		leading := uint8(bits.Clz(vDelta))
-		trailing := uint8(bits.Ctz(vDelta))
+		leading := uint8(bits.LeadingZeros64(vDelta))
+		trailing := uint8(bits.TrailingZeros64(vDelta))
 
 		// clamp number of leading zeros to avoid overflow when encoding
 		if leading >= 32 {


### PR DESCRIPTION
The [math/bits](https://golang.org/pkg/math/bits/) library now provides some pretty quick `LeadingZeros64` & `TrailingZeros64` functions.

I ran a quick bench mark to confirm:

```
sunny.klair:scratch$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/dgryski/go-bits
BenchmarkCtzFast-4              	2000000000	         1.44 ns/op
BenchmarkGoMathBitsTrailing-4   	2000000000	         0.28 ns/op
BenchmarkClzFast-4              	2000000000	         1.48 ns/op
BenchmarkGoMathBitsLeading-4    	2000000000	         0.29 ns/op
PASS
ok  	workspace/scratch	7.347s
```
https://gist.github.com/sunhay/4671ddbff6ec9a1f911ae58bde7cf4a6