### PR TITLE
Use uint64 type for timestamps

### DIFF
--- a/testdata/data.go
+++ b/testdata/data.go
@@ -2,7 +2,7 @@ package testdata
 
 type Point struct {
 	V float64
-	T uint32
+	T uint64
 }
 
 // 120 points every 60s

--- a/tsz.go
+++ b/tsz.go
@@ -20,9 +20,8 @@ import (
 type Series struct {
 	sync.Mutex
 
-	// TODO(dgryski): timestamps in the paper are uint64
-	T0  uint32
-	t   uint32
+	T0  uint64
+	t   uint64
 	val float64
 
 	bw       bstream
@@ -30,11 +29,11 @@ type Series struct {
 	trailing uint8
 	finished bool
 
-	tDelta uint32
+	tDelta uint64
 }
 
 // New series
-func New(t0 uint32) *Series {
+func New(t0 uint64) *Series {
 	s := Series{
 		T0:      t0,
 		leading: ^uint8(0),
@@ -72,7 +71,7 @@ func (s *Series) Finish() {
 }
 
 // Push a timestamp and value to the series
-func (s *Series) Push(t uint32, v float64) {
+func (s *Series) Push(t uint64, v float64) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -159,9 +158,9 @@ func (s *Series) Iter() *Iter {
 
 // Iter lets you iterate over a series.  It is not concurrency-safe.
 type Iter struct {
-	T0 uint32
+	T0 uint64
 
-	t   uint32
+	t   uint64
 	val float64
 
 	br       bstream
@@ -170,7 +169,7 @@ type Iter struct {
 
 	finished bool
 
-	tDelta uint32
+	tDelta uint64
 	err    error
 }
 
@@ -184,7 +183,7 @@ func bstreamIterator(br *bstream) (*Iter, error) {
 	}
 
 	return &Iter{
-		T0: uint32(t0),
+		T0: t0,
 		br: *br,
 	}, nil
 }
@@ -208,7 +207,7 @@ func (it *Iter) Next() bool {
 			it.err = err
 			return false
 		}
-		it.tDelta = uint32(tDelta)
+		it.tDelta = tDelta
 		it.t = it.T0 + it.tDelta
 		v, err := it.br.readBits(64)
 		if err != nil {
@@ -236,7 +235,7 @@ func (it *Iter) Next() bool {
 		d |= 1
 	}
 
-	var dod int32
+	var dod int64
 	var sz uint
 	switch d {
 	case 0x00:
@@ -260,7 +259,7 @@ func (it *Iter) Next() bool {
 			return false
 		}
 
-		dod = int32(bits)
+		dod = int64(bits)
 	}
 
 	if sz != 0 {
@@ -273,10 +272,10 @@ func (it *Iter) Next() bool {
 			// or something
 			bits = bits - (1 << sz)
 		}
-		dod = int32(bits)
+		dod = int64(bits)
 	}
 
-	tDelta := it.tDelta + uint32(dod)
+	tDelta := it.tDelta + uint64(dod)
 
 	it.tDelta = tDelta
 	it.t = it.t + it.tDelta
@@ -335,7 +334,7 @@ func (it *Iter) Next() bool {
 }
 
 // Values at the current iterator position
-func (it *Iter) Values() (uint32, float64) {
+func (it *Iter) Values() (uint64, float64) {
 	return it.t, it.val
 }
 

--- a/tsz_test.go
+++ b/tsz_test.go
@@ -81,7 +81,7 @@ func TestExampleEncoding(t *testing.T) {
 
 	// Example from the paper
 	t0, _ := time.ParseInLocation("Jan _2 2006 15:04:05", "Mar 24 2015 02:00:00", time.Local)
-	tunix := uint32(t0.Unix())
+	tunix := uint64(t0.Unix())
 
 	s := New(tunix)
 
@@ -115,9 +115,9 @@ func TestExampleEncoding(t *testing.T) {
 
 	it := s.Iter()
 
-	tunix = uint32(t0.Unix())
+	tunix = uint64(t0.Unix())
 	want := []struct {
-		t uint32
+		t uint64
 		v float64
 	}{
 		{tunix + 62, 12},
@@ -305,10 +305,10 @@ func BenchmarkDecodeByteSlice(b *testing.B) {
 }
 
 func TestEncodeSimilarFloats(t *testing.T) {
-	tunix := uint32(time.Unix(0, 0).Unix())
+	tunix := uint64(time.Unix(0, 0).Unix())
 	s := New(tunix)
 	want := []struct {
-		t uint32
+		t uint64
 		v float64
 	}{
 		{tunix, 6.00065e+06},


### PR DESCRIPTION
This commit changes the numeric type of the timestamps from uint32 to uint64 as described in the paper.

As this is a breaking change, I'd recommend we introduce semantic versioning in this library.

For context, this change is a prerequisite for me to adopt this library in Vegeta for use in the `plot` command that ought to handle larger data sets gracefully. 

